### PR TITLE
New Feature added to import GitHub repository from Bitbucket side

### DIFF
--- a/.mocharc.json
+++ b/.mocharc.json
@@ -1,0 +1,6 @@
+{
+	"spec": "test/**/*.spec.js",
+	"timeout": 5000,
+	"exit": true,
+	"color": true
+}

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Hey there! 👋 Welcome to our migration tools repository – your go-to toolkit
 | 6. Delete repositories                    | ✅ [delete-github-repos](https://github.com/ModusCreateOrg/gh-migration-scripts?tab=readme-ov-file#2-delete-github-repos)                             |
 | 7. Import organization memberships        | ✅ [import-github-membership-in-org](https://github.com/ModusCreateOrg/gh-migration-scripts?tab=readme-ov-file#import-github-membership-in-org)       |
 | 8. Import organization projects           | ✅ [import-github-projects-v2](https://github.com/ModusCreateOrg/gh-migration-scripts?tab=readme-ov-file#import-github-projects-v2)                   |
+| 9. Import repository on gh from bb        | ✅ [import-github-repo-from-bitbucket](https://github.com/ModusCreateOrg/gh-migration-scripts?tab=readme-ov-file#import-github-repo-from-bitbucket)   |
 
 # How it works
 
@@ -372,6 +373,37 @@ No input file is required
 #### Output
 
 Output is a JSON file with projects info.
+
+### 9. Import github Repo from bitbucket
+
+#### import-github-repo-from-bitbucket
+
+Imports repositories on GitHub from Bitbucket.
+
+#### Usage
+
+```
+git-migrator import-github-repo-from-bitbucket
+```
+
+#### Arguments
+
+1. `-f` or `--input-file` - Input file name with repo, team & permission info.
+2. `-o` or `--organization` - Organization name.
+3. `-g` or `--server-url` - The target GHES server endpoint url. If this argument is skipped then the target will the cloud instance.
+4. `-y` or `--output-file` - Output file to save the operation results. If not provided, the default file the results saved is `<organization>-set-repo-team-permission-status-<timestamp>.csv`. This output file logs the successful teams permissions added to repositories.
+5. `-t` or `--token` - Personal access token.
+6. `-r` or `--repos-file` - File with repos names so only those repos will be considered. Should have the column `repos`.
+7. `-s` or `--skip` - Number of lines to skip in the input file. Default is set to 0.
+8. `-w` or `--wait-time` - Delay time (in seconds) to wait between requests. Default value is 1 second.
+
+#### Input
+
+```
+git-migrator import-github-repo-from-bitbucket -f user-bitbucket-repo-9:19:2024-8:31:59-AM.csv
+```
+
+> **Note:** Input the **.csv** file generated in the previous `git-migrator export-bitbucket-repos -o org --server-url https://api.bitbucket.org/2.0` command.
 
 ### B. Bitbucket
 

--- a/src/api/import/github/repos/import-github-repo-from-bitbucket.js
+++ b/src/api/import/github/repos/import-github-repo-from-bitbucket.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+import axios from 'axios';
+import csv from 'fast-csv';
+import fs from 'fs';
+import path from 'path';
+import { GITHUB_API_URL } from '../../../../services/constants.js';
+import { exec } from 'child_process';
+import util from 'util';
+
+const execPromise = util.promisify(exec);
+
+const createGitHubRepository = async (data) => {
+	try {
+		const GITHUB_TOKEN = process.env.GITHUB_TOKEN;
+		const response = await axios.post(`${GITHUB_API_URL}/user/repos`, data, {
+			headers: {
+				Accept: 'application/vnd.github+json',
+				Authorization: `Bearer ${GITHUB_TOKEN}`,
+			},
+		});
+
+		if (response.status === 201) {
+			console.log('Repository created successfully!');
+			return true;
+		} else {
+			console.log(`Received status code ${response.status}:`, response.data);
+			return false;
+		}
+	} catch (error) {
+		console.error(
+			'Error creating repository:',
+			error.response ? error.response.data : error.message,
+		);
+		return false;
+	}
+};
+
+const createRepository = async (repoData) => {
+	const { repoName, repoDescription, repoVisibility } = repoData;
+	const isPrivate = repoVisibility === 'private';
+	const data = {
+		name: repoName,
+		description: repoDescription,
+		private: isPrivate,
+		has_issues: true,
+		has_projects: true,
+		has_wiki: true,
+	};
+
+	console.log(`Creating the repository ${repoName}`);
+	const wasCreated = await createGitHubRepository(data);
+
+	if (wasCreated) {
+		console.log(`Repository ${repoName} created successfully on GitHub side!`);
+	} else {
+		console.error(`Failed to create repository ${repoName}.`);
+	}
+};
+
+const readRepositoryData = async (options) => {
+	const csvFilePath = path.join(process.cwd(), options.inputFile);
+
+	return new Promise((resolve, reject) => {
+		const rows = [];
+		const creationPromises = [];
+
+		fs.createReadStream(csvFilePath)
+			.pipe(csv.parse({ headers: true }))
+			.on('data', (row) => {
+				const repoData = {
+					repoName: row.repo,
+					repoDescription: row.description,
+					repoUrl: row.url,
+					repoVisibility: row.visibility,
+				};
+
+				const creationPromise = createRepository(repoData);
+				creationPromises.push(creationPromise);
+
+				rows.push(row);
+			})
+			.on('end', async () => {
+				console.log('CSV file successfully processed');
+
+				try {
+					await Promise.all(creationPromises);
+					resolve(rows);
+				} catch (error) {
+					reject(error);
+				}
+			})
+			.on('error', (err) => {
+				console.error('Error reading the CSV file:', err);
+				reject(err);
+			});
+	});
+};
+
+const migrateRepository = async (repoData) => {
+	const GITHUB_USERNAME = process.env.GITHUB_USERNAME;
+	const { repoName, repoUrl } = repoData;
+	const githubRepoUrl = `https://github.com/${GITHUB_USERNAME}/${repoName}.git`;
+	const tempFolderPath = path.join(process.cwd(), 'tmp');
+	const repoDir = path.join(tempFolderPath, repoName);
+
+	try {
+		if (!fs.existsSync(tempFolderPath)) {
+			fs.mkdirSync(tempFolderPath, { recursive: true });
+		}
+
+		console.log(`Cloning repo ${repoName} from Bitbucket into ${repoDir}...`);
+		await execPromise(`git clone --mirror ${repoUrl} ${repoDir}`);
+		await execPromise(`git -C ${repoDir} remote add github ${githubRepoUrl}`);
+		await execPromise(`git -C ${repoDir} push github --mirror`);
+
+		fs.rmSync(repoDir, { recursive: true, force: true });
+
+		console.log(`Repository ${repoName} migrated successfully.`);
+	} catch (error) {
+		console.error(`Error migrating repository ${repoName}:`, error.message);
+	}
+};
+
+const migrateRepositoryData = async (options) => {
+	const csvFilePath = path.join(process.cwd(), options.inputFile);
+	const rows = [];
+
+	return new Promise((resolve, reject) => {
+		const readStream = fs.createReadStream(csvFilePath);
+		const parser = csv.parse({ headers: true });
+		readStream
+			.pipe(parser)
+			.on('data', (row) => {
+				rows.push({
+					repoName: row.repo,
+					repoUrl: row.url,
+				});
+			})
+			.on('end', async () => {
+				console.log('CSV file successfully processed for migration!');
+
+				for (const repoData of rows) {
+					try {
+						await migrateRepository(repoData);
+					} catch (error) {
+						console.error(
+							`Error migrating repository ${repoData.repoName}:`,
+							error.message,
+						);
+					}
+				}
+
+				resolve(rows);
+			})
+			.on('error', (err) => {
+				console.error('Error reading the CSV file:', err);
+				reject(err);
+			});
+	});
+};
+
+const importGithubRepoFromBitbucket = async (options) => {
+	console.log('Starting the importing process...');
+	try {
+		await readRepositoryData(options);
+		await migrateRepositoryData(options);
+		console.log('Importing process done!');
+	} catch (err) {
+		console.error('Error during import:', err);
+	}
+};
+
+export default importGithubRepoFromBitbucket;

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,7 @@
 #!/usr/bin/env node
 /* eslint-disable no-undef */
+import dotenv from 'dotenv';
+dotenv.config();
 
 import { program } from 'commander';
 import { commandController } from './commands/commands.js';
@@ -29,6 +31,7 @@ import exportGithubProjectsV1 from './api/export/github/projects/export-github-p
 import exportGithubProjectsV2 from './api/export/github/projects/export-github-projects-v2.js';
 import importGithubProjectsV2 from './api/import/github/projects/import-github-projects-v2.js';
 import exportGithubRepoBranches from './api/export/github/repos/export-github-repo-branches.js';
+import importGithubRepoFromBitbucket from './api/import/github/repos/import-github-repo-from-bitbucket.js';
 
 // GitLab
 import exportGitlabRepositories from './api/export/gitlab/repos/export-gitlab-repos.js';
@@ -463,6 +466,15 @@ program
 	.description('Exports branches of given repositories of an organization')
 	.action(async (args) =>
 		commandController(process.env.PAT, args, exportGithubRepoBranches),
+	);
+
+program
+	.command(getFunctionName(importGithubRepoFromBitbucket))
+	.option(args.inputFile.argument, 'Input file name with repository names')
+	.alias('igrfb')
+	.description('Import all github repositories from bitbucket')
+	.action(async (args) =>
+		commandController(process.env.PAT, args, importGithubRepoFromBitbucket),
 	);
 
 program

--- a/test/api/export/bitbucket/repos/export-bitbucket-repos.spec.js
+++ b/test/api/export/bitbucket/repos/export-bitbucket-repos.spec.js
@@ -1,0 +1,69 @@
+import { expect } from 'chai';
+import { processRepositories } from '../../../../../src/api/export/bitbucket/repos/export-bitbucket-repos.js';
+import { columns } from '../../../../../src/api/export/bitbucket/repos/export-bitbucket-repos.js';
+import exportBitbucketRepos from '../../../../../src/api/export/bitbucket/repos/export-bitbucket-repos.js';
+
+describe('exportBitbucketRepos', function () {
+	let mockStringifier;
+
+	beforeEach(function () {
+		mockStringifier = {
+			write: function (row) {
+				this.rows.push(row);
+			},
+			rows: [],
+		};
+	});
+
+	it('should processRepositories writes correct rows', function () {
+		const values = [
+			{
+				name: 'FakeRepo1',
+				description: 'Description of FakeRepo1',
+				is_private: false,
+				links: {
+					clone: [
+						{ name: 'https', href: 'https://fakerepo1.com' },
+						{ name: 'ssh', href: 'ssh://fakerepo1.com' },
+					],
+				},
+			},
+			{
+				name: 'FakeRepo2',
+				description: 'Description of FakeRepo2',
+				is_private: true,
+				links: {
+					clone: [{ name: 'https', href: 'https://fakerepo2.com' }],
+				},
+			},
+		];
+
+		processRepositories(values, mockStringifier);
+
+		expect(mockStringifier.rows).to.have.lengthOf(2);
+		expect(mockStringifier.rows).to.deep.include({
+			repo: 'FakeRepo1',
+			description: 'Description of FakeRepo1',
+			url: 'https://fakerepo1.com',
+			visibility: 'public',
+		});
+		expect(mockStringifier.rows).to.deep.include({
+			repo: 'FakeRepo2',
+			description: 'Description of FakeRepo2',
+			url: 'https://fakerepo2.com',
+			visibility: 'private',
+		});
+	});
+
+	it('should columns have specific properties', function () {
+		expect(columns.length).to.equal(4);
+		expect(columns).to.deep.equal(['repo', 'description', 'url', 'visibility']);
+		expect(columns).to.be.an('array');
+		expect(columns).to.be.an('array').that.is.not.null;
+	});
+
+	it('should exportBitbucketRepos be a function', function () {
+		expect(exportBitbucketRepos).to.be.an('function');
+	});
+});
+// TODO: Add more tests

--- a/test/api/import/github/repos/import-github-repo-from-bitbucket.spec.js
+++ b/test/api/import/github/repos/import-github-repo-from-bitbucket.spec.js
@@ -1,0 +1,81 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+import fs from 'fs';
+import axios from 'axios';
+import util from 'util';
+import { Readable } from 'stream';
+
+process.env.GITHUB_TOKEN = 'mock_github_token';
+process.env.GITHUB_USERNAME = 'mock_github_username';
+
+describe('importGithubRepoFromBitbucket', function () {
+	let axiosPostStub;
+	let execPromiseStub;
+	let fsCreateReadStreamStub;
+	let sandbox;
+
+	beforeEach(() => {
+		sandbox = sinon.createSandbox();
+
+		axiosPostStub = sandbox
+			.stub(axios, 'post')
+			.resolves({ status: 201, data: {} });
+
+		execPromiseStub = sandbox.stub(util, 'promisify').callsFake(() => {
+			return (command) => {
+				if (command.includes('echo git clone')) {
+					return Promise.resolve('Simulated git clone');
+				} else if (command.includes('echo git remote add')) {
+					return Promise.resolve('Simulated git remote add');
+				} else if (command.includes('echo git push')) {
+					return Promise.resolve('Simulated git push');
+				} else {
+					return Promise.reject(
+						new Error('Simulated error for invalid command'),
+					);
+				}
+			};
+		});
+
+		fsCreateReadStreamStub = sandbox
+			.stub(fs, 'createReadStream')
+			.callsFake((filePath) => {
+				if (filePath.includes('mock.csv')) {
+					const fakeCSVData =
+						'repo,description,url,visibility\n' +
+						'test-repo,A test repo,https://bitbucket.org/test-repo.git,public\n';
+
+					const readable = new Readable({
+						read() {
+							this.push(fakeCSVData);
+							this.push(null);
+						},
+					});
+
+					return readable;
+				}
+				throw new Error('File not found');
+			});
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	it('should successfully import and migrate GitHub repositories from Bitbucket', async () => {
+		try {
+			await importGithubRepoFromBitbucket({ inputFile: 'mock.csv' });
+
+			expect(axiosPostStub.calledOnce).to.be.true;
+			expect(execPromiseStub.called).to.be.true;
+			expect(fsCreateReadStreamStub.calledOnce).to.be.true;
+		} catch (error) {
+			expect('Test failed with error: ' + error.message);
+		}
+	});
+
+	it('should have non-empty environment variables', () => {
+		expect(process.env.GITHUB_TOKEN).to.not.be.empty;
+		expect(process.env.GITHUB_USERNAME).to.not.be.empty;
+	});
+});

--- a/test/index.spec.js
+++ b/test/index.spec.js
@@ -1,0 +1,40 @@
+import { expect } from 'chai';
+import fs from 'fs';
+import path from 'path';
+
+describe('src/index.js', function () {
+	let fileContent;
+
+	before(function () {
+		const filePath = path.resolve('src/index.js');
+		fileContent = fs.readFileSync(filePath, 'utf8');
+	});
+
+	it('should have the import statement for program', function () {
+		const importProgram = "import { program } from 'commander';";
+
+		expect(fileContent).to.include(
+			importProgram,
+			'The import statement for program should be present in src/index.js',
+		);
+	});
+
+	it('should have the import statement for commandController', function () {
+		const importCommandController =
+			"import { commandController } from './commands/commands.js';";
+
+		expect(fileContent).to.include(
+			importCommandController,
+			'The import statement for commandController should be present in src/index.js',
+		);
+	});
+	it('should have the import statement for getFunctionName', function () {
+		const importGetFunctionName =
+			"import { getFunctionName } from './services/utils.js';";
+
+		expect(fileContent).to.include(
+			importGetFunctionName,
+			'The import statement for importGetFunctionName should be present in src/index.js',
+		);
+	});
+});


### PR DESCRIPTION
### Change

This implementation export repositories from BitBucket side, data like: **repo name**, **description**, **url**, and **visibility**. The next step is use the import those data into GitHub side.

### Does this PR introduce a breaking change?

No, it doesn't.

### What needs to be documented once your changes are merged?

I'll add in the README.md file the commands for this case.

### Additional Comments

In the export command, a **.csv** file will be generated, this file will be the input for the next import command.
Also, to this works properly, it should have a **.env** file with the following content:

```
PAT='BITBUCKET-PERSONAL-TOKEN'
GITHUB_USERNAME='john-doe-user'
GITHUB_TOKEN='github_pat_123_ABC'
```
